### PR TITLE
Align comment style with zeek comment style so docs generation works

### DIFF
--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -18,24 +18,24 @@ export {
     ################################  Control -> dnp3_control.log  ################################
     ###############################################################################################
     type Control: record {
-        ts                      : time      &log;             # Timestamp of event
-        uid                     : string    &log;             # Zeek unique ID for connection
-        id                      : conn_id   &log;             # Zeek connection struct (addresses and ports)
-        is_orig                 : bool      &optional &log;   # the message came from the originator/client or the responder/server
-        source_h                : addr      &optional &log;   # Source IP Address
-        source_p                : port      &optional &log;   # Source Port
-        destination_h           : addr      &optional &log;   # Destination IP Address
-        destination_p           : port      &optional &log;   # Destination Port
-        block_type              : string    &optional &log;   # Control_Relay_Output_Block or Pattern_Control_Block
-        function_code           : string    &optional &log;   # Function Code (SELECT, OPERATE, RESPONSE)
-        index_number            : count     &optional &log;   # Object Index #
-        trip_control_code       : string    &optional &log;   # Nul, Close, or Trip
-        operation_type          : string    &optional &log;   # Nul, Pulse_On, Pulse_Off, Latch_On, Latch_Off
-        clear_bit               : bool      &optional &log;   # Control code clear bit set (T) or unset (F)
-        execute_count           : count     &optional &log;   # Number of times to execute
-        on_time                 : count     &optional &log;   # On Time
-        off_time                : count     &optional &log;   # Off Time
-        status_code             : string    &optional &log;   # Status Code (see control_block_status_codes)
+        ts                      : time      &log;             ##< Timestamp of event
+        uid                     : string    &log;             ##< Zeek unique ID for connection
+        id                      : conn_id   &log;             ##< Zeek connection struct (addresses and ports)
+        is_orig                 : bool      &optional &log;   ##< the message came from the originator/client or the responder/server
+        source_h                : addr      &optional &log;   ##< Source IP Address
+        source_p                : port      &optional &log;   ##< Source Port
+        destination_h           : addr      &optional &log;   ##< Destination IP Address
+        destination_p           : port      &optional &log;   ##< Destination Port
+        block_type              : string    &optional &log;   ##< Control_Relay_Output_Block or Pattern_Control_Block
+        function_code           : string    &optional &log;   ##< Function Code (SELECT, OPERATE, RESPONSE)
+        index_number            : count     &optional &log;   ##< Object Index #
+        trip_control_code       : string    &optional &log;   ##< Nul, Close, or Trip
+        operation_type          : string    &optional &log;   ##< Nul, Pulse_On, Pulse_Off, Latch_On, Latch_Off
+        clear_bit               : bool      &optional &log;   ##< Control code clear bit set (T) or unset (F)
+        execute_count           : count     &optional &log;   ##< Number of times to execute
+        on_time                 : count     &optional &log;   ##< On Time
+        off_time                : count     &optional &log;   ##< Off Time
+        status_code             : string    &optional &log;   ##< Status Code (see control_block_status_codes)
     };
     global log_control: event(rec: Control);
 
@@ -43,19 +43,19 @@ export {
     ################################  Objects -> dnp3_objects.log  ################################
     ###############################################################################################
     type Objects: record {
-        ts                      : time      &log;             # Timestamp of event
-        uid                     : string    &log;             # Zeek unique ID for connection
-        id                      : conn_id   &log;             # Zeek connection struct (addresses and ports)
-        is_orig                 : bool      &optional &log;   # the message came from the originator/client or the responder/server
-        source_h                : addr      &optional &log;   # Source IP Address
-        source_p                : port      &optional &log;   # Source Port
-        destination_h           : addr      &optional &log;   # Destination IP Address
-        destination_p           : port      &optional &log;   # Destination Port
-        function_code           : string    &optional &log;   # Function Code (READ or RESPONSE)
-        object_type             : string    &optional &log;   # Object type (see dnp3_objects)
-        object_count            : count     &optional &log;   # Number of objects
-        range_low               : count     &optional &log;   # Range (Low) of object
-        range_high              : count     &optional &log;   # Range (High) of object
+        ts                      : time      &log;             ##< Timestamp of event
+        uid                     : string    &log;             ##< Zeek unique ID for connection
+        id                      : conn_id   &log;             ##< Zeek connection struct (addresses and ports)
+        is_orig                 : bool      &optional &log;   ##< the message came from the originator/client or the responder/server
+        source_h                : addr      &optional &log;   ##< Source IP Address
+        source_p                : port      &optional &log;   ##< Source Port
+        destination_h           : addr      &optional &log;   ##< Destination IP Address
+        destination_p           : port      &optional &log;   ##< Destination Port
+        function_code           : string    &optional &log;   ##< Function Code (READ or RESPONSE)
+        object_type             : string    &optional &log;   ##< Object type (see dnp3_objects)
+        object_count            : count     &optional &log;   ##< Number of objects
+        range_low               : count     &optional &log;   ##< Range (Low) of object
+        range_high              : count     &optional &log;   ##< Range (High) of object
     };
     global log_objects: event(rec: Objects);
 }


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

When you do single line comments in Zeek, zeekygen expects ##< to signal where they apply, so changed single hashes to those.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Fixes automated documentation and schema generation.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
